### PR TITLE
remove async_forward_entry_setup and add state_class 

### DIFF
--- a/custom_components/apex/__init__.py
+++ b/custom_components/apex/__init__.py
@@ -59,10 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
-    for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def async_set_options_service(service_call):
         await hass.async_add_executor_job(set_output, hass, service_call, coordinator)


### PR DESCRIPTION
Switch from async_forward_entry_setup since it is deprecated in favor of async_forward_entry_setups and being removed shortly.
I also added a state_class of measurement to the sensors so that they will retain long term statistics.