### PR TITLE
OptionsFlow throwing 500 error

### DIFF
--- a/custom_components/apex/config_flow.py
+++ b/custom_components/apex/config_flow.py
@@ -84,7 +84,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class OptionsFlow(config_entries.OptionsFlow):
     def __init__(self, config_entry: config_entries.ConfigEntry):
         """Initialize options flow."""
-        self._config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         if user_input is not None:

--- a/custom_components/apex/config_flow.py
+++ b/custom_components/apex/config_flow.py
@@ -84,7 +84,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class OptionsFlow(config_entries.OptionsFlow):
     def __init__(self, config_entry: config_entries.ConfigEntry):
         """Initialize options flow."""
-        self.config_entry = config_entry
+        self._config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         if user_input is not None:


### PR DESCRIPTION
Clicking on the options gearbox next to the server definition on an existing installation would cause a 500 error with the following message in the log:

```
AttributeError: property 'config_entry' of 'OptionsFlow' object has no setter
```

Removing this properly resolves the problem. 